### PR TITLE
Allow DRI device access

### DIFF
--- a/com.github.giacomogroppi.writernote-qt.json
+++ b/com.github.giacomogroppi.writernote-qt.json
@@ -5,6 +5,7 @@
   "sdk": "org.kde.Sdk",
   "command": "writernote",
   "finish-args": [
+    "--device=dri",
     "--socket=x11",
     "--socket=pulseaudio",
     "--share=ipc"


### PR DESCRIPTION
This is needed for GPU accelerated rendering.  
With the default XCB platform, I'm getting the following error:
```
libGL error: MESA-LOADER: failed to retrieve device information
```
and with Wayland platform
```
libEGL warning: wayland-egl: could not open /dev/dri/renderD128 (No such file or directory)
```