### PR TITLE
Add Wayland socket access and switch to fallback-x11

### DIFF
--- a/com.github.giacomogroppi.writernote-qt.json
+++ b/com.github.giacomogroppi.writernote-qt.json
@@ -6,9 +6,10 @@
   "command": "writernote",
   "finish-args": [
     "--device=dri",
-    "--socket=x11",
+    "--share=ipc",
+    "--socket=fallback-x11",
     "--socket=pulseaudio",
-    "--share=ipc"
+    "--socket=wayland"
   ],
   "cleanup": [
     "/lib/pkgconfig",

--- a/com.github.giacomogroppi.writernote-qt.json
+++ b/com.github.giacomogroppi.writernote-qt.json
@@ -68,7 +68,7 @@
         {
           "type": "git",
           "url": "https://github.com/giacomogroppi/writernote-qt",
-          "commit": "c4bba675d91298fb3ae85f5594e91fdb00e74caa"
+          "commit": "aff0ab247560b03b273ddc67ee7c003612f0e02e"
         }
       ]
     }


### PR DESCRIPTION
Switch to fallback-x11 to block access to the X11 socket if Wayland is available.  
Except of the usual security reasoning, with Qt 6.2 there's another rational to want this, and it's [Qt's behavior of defaulting to XCB platform if `XDG_CURRENT_DESTKOP` contains `gnome` and the X11 socket is available](https://invent.kde.org/qt/qt/qtbase/-/blob/6.2.4/src/gui/kernel/qguiapplication.cpp#L1413).  
This silliness [seems to be fixed in Qt 6.3](https://invent.kde.org/qt/qt/qtbase/-/blob/6.3.0/src/gui/kernel/qguiapplication.cpp#L1412).