### PR TITLE
Update runtime to KDE 6.3

### DIFF
--- a/com.github.giacomogroppi.writernote-qt.json
+++ b/com.github.giacomogroppi.writernote-qt.json
@@ -1,7 +1,7 @@
 {
   "app-id": "com.github.giacomogroppi.writernote-qt",
   "runtime": "org.kde.Platform",
-  "runtime-version": "6.2",
+  "runtime-version": "6.3",
   "sdk": "org.kde.Sdk",
   "command": "writernote",
   "finish-args": [


### PR DESCRIPTION
This builds and runs fine here.  
I can't test stylus input, as the solution I'm using, Apple Pencil + [Weylus](https://github.com/H-M-H/Weylus) doesn't work well for currently.  
A major change in Qt6.3 is finally prioritizing Wayland, no mater what desktop environment is running (or what set in XDG_CURRENT_DESTKOP), even if X11 socket is available. This needs to take into consideration before Wayland socket is added, to avoid possible regressions.